### PR TITLE
[feat] 저장된 사용자 사진 url과 상품 url로 가상 피팅 사진 2장 생성

### DIFF
--- a/fitting/serializers.py
+++ b/fitting/serializers.py
@@ -12,3 +12,8 @@ class VTORequestSerializer(serializers.Serializer):
 class GenerateVTORequestSerializer(serializers.Serializer):
     person_image_id = serializers.CharField(help_text="사람 이미지 ID")
     outfit_image_id = serializers.CharField(help_text="옷 이미지 ID")
+
+class GenerateVTOProductRequestSerializer(serializers.Serializer):
+    person_image_url  = serializers.URLField()
+    outfit_image_url  = serializers.URLField()
+    category = serializers.CharField()

--- a/fitting/tasks.py
+++ b/fitting/tasks.py
@@ -51,3 +51,46 @@ def collect_paths(results):
     그대로 반환하거나 후처리(저장·DB업데이트 등) 가능
     """
     return results  # 필요하면 JSON 직렬화 등 추가
+
+# fitting/tasks.py  (추가 부분만)
+@shared_task(bind=True, max_retries=3, default_retry_delay=5)
+def run_vto_url_task(self, person_url, outfit_url, prompt):
+    """
+    Bitstudio에 URL만 넘겨 VTO 1장을 생성 → 완료 path | None
+    """
+    try:
+        # ① 작업 시작
+        r = requests.post(
+            "https://api.bitstudio.ai/images/virtual-try-on",
+            headers={"Authorization": f"Bearer {BITSTUDIO_API_KEY}",
+                     "Content-Type": "application/json"},
+            json={
+                "person_image_url":  person_url,
+                "outfit_image_url":  outfit_url,
+                "prompt":            prompt,
+                "resolution":        "standard",
+                "num_images":        1,
+                "style":             "studio",
+            },
+            timeout=30,
+        )
+        r.raise_for_status()
+        job_id = r.json()[0]["id"]
+
+        # ② 완료 폴링 (2 초 × 30 = 60 초)
+        for _ in range(30):
+            info = requests.get(
+                f"https://api.bitstudio.ai/images/{job_id}",
+                headers={"Authorization": f"Bearer {BITSTUDIO_API_KEY}"},
+                timeout=10,
+            ).json()
+
+            if info.get("status") == "completed":
+                return info.get("path")
+            if info.get("status") == "failed":
+                return None
+            time.sleep(2)
+
+        return None            # 타임아웃
+    except Exception as exc:
+        raise self.retry(exc=exc)

--- a/fitting/urls.py
+++ b/fitting/urls.py
@@ -3,4 +3,5 @@ from .views import *
 
 urlpatterns = [
     path('images',VTOOneShotView.as_view(),name='generate_vto'),
+    path('images/products',VTOProductView.as_view(),name='generate_vto_product'),
 ]

--- a/fitting/views.py
+++ b/fitting/views.py
@@ -10,11 +10,11 @@ from django.conf import settings
 from openai import OpenAI
 from rest_framework.parsers import MultiPartParser, FormParser
 import base64
-from .serializers import GenerateVTORequestSerializer, VTORequestSerializer
+from .serializers import GenerateVTORequestSerializer, VTORequestSerializer, GenerateVTOProductRequestSerializer
 import requests
 from rest_framework.permissions import AllowAny
 from celery import chord
-from .tasks import run_vto_task, collect_paths
+from .tasks import run_vto_task, collect_paths, run_vto_url_task
 
 BITSTUDIO_API_KEY = os.getenv("BITSTUDIO_API_KEY")
 load_dotenv()
@@ -93,7 +93,7 @@ class VTOOneShotView(GenericAPIView):
             "Frontal shot, arms crossed. " + base_prompt,
             "Frontal shot, hands in pockets. " + base_prompt,
             "Standing at attention. " + base_prompt,
-]
+            ]
 
         # 4) Celery chord 실행
         header = [run_vto_task.s(person_id, outfit_id, p) for p in prompts]
@@ -129,3 +129,73 @@ class VTOOneShotView(GenericAPIView):
         )
         res.raise_for_status()
         return res.json()["id"]
+    
+class VTOProductView(GenericAPIView):
+    permission_classes = [AllowAny]
+    serializer_class   = GenerateVTOProductRequestSerializer
+
+    @swagger_auto_schema(
+        operation_summary="상품-URL VTO (2장 병렬)",
+        request_body=GenerateVTOProductRequestSerializer,   # ← 새 스키마
+        responses={200: openapi.Response("OK")},
+    )
+    def post(self, request):
+        # 1) 입력 검증
+        ser = self.get_serializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        d = ser.validated_data
+
+        person_url  = d["person_image_url"]
+        outfit_url  = d["outfit_image_url"]
+        category    = d["category"]        # 상의 / 하의 / 기타
+
+        # 2) 카테고리에 따라 안내 문구(garment_clause) 결정
+        if category == "상의":
+            garment_clause = (
+                "Replace only the upper garment with the input clothing, "
+                "leaving all other clothes unchanged. "
+            )
+        elif category == "하의":
+            garment_clause = (
+                "Replace only the lower garment with the input clothing, "
+                "leaving all other clothes unchanged. "
+            )
+        else:
+            garment_clause = ""
+
+        # 3) 공통 프롬프트 (category 반영)
+        base_prompt = (
+            "Generate a realistic, high-quality full-body image of the input person "
+            "wearing the input clothing. "
+            f"{garment_clause}"
+            "Ensure the clothes fit naturally to the body shape and preserve the "
+            "person's facial features, skin tone, and hair. "
+        )
+
+        prompts = [
+            base_prompt,                                  # ① 현재 자세
+            "Standing at attention. " + base_prompt,      # ② 차렷 자세
+        ]
+
+        # 4) Celery chord (2개 병렬)
+        header = [
+            run_vto_url_task.s(person_url, outfit_url, p)
+            for p in prompts
+        ]
+        result_async = chord(header)(collect_paths.s())
+
+        try:
+            paths = result_async.get(timeout=120)  # [path1, path2] or None
+        except Exception as exc:
+            return Response(
+                {"error": f"VTO 작업 수집 실패: {exc}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        if any(p is None for p in paths):
+            return Response(
+                {"error": "VTO 생성 실패/타임아웃", "paths": paths},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        return Response({"paths": paths}, status=200)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ celery==5.5.2
 django-celery-beat==2.8.0
 django_celery_results==2.6.0
 kombu==5.5.3
+boto3==1.39.4


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

저장된 사용자 사진 url과 상품 url로 가상 피팅 사진 2장 생성

### ✨ Description

<!-- write down the work details and show the execution results. -->
마찬가지로 비동기로 처리했고 입력값은 url입니다. s3에 저장된 사용자 url과 상품 url입니다.
<img width="1174" height="476" alt="image" src="https://github.com/user-attachments/assets/bc1e6f77-0f4f-4872-98e1-59af30709b10" />


### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{22}
