### PR TITLE
[feat] 사용자 사진과 피팅 결과 s3에 저장 후 url을 db에 저장

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -30,6 +30,7 @@ INSTALLED_APPS = [
     'fitting',
     'django_celery_results',
     'django_celery_beat',
+    'storages',
 ]
 
 MIDDLEWARE = [
@@ -158,3 +159,18 @@ CELERY_RESULT_BACKEND = "django-db"
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 
 CELERY_RESULT_BACKEND = os.getenv('CELERY_RESULT_BACKEND', 'redis://redis:6379/0')
+
+AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID')
+AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY')
+AWS_STORAGE_BUCKET_NAME = os.getenv('AWS_STORAGE_BUCKET_NAME')
+AWS_S3_CUSTOM_DOMAIN = os.getenv('AWS_S3_CUSTOM_DOMAIN')
+
+DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+
+AWS_S3_OBJECT_PARAMETERS = {
+    'CacheControl': 'max-age=86400',
+}
+
+AWS_DEFAULT_ACL = None
+
+MEDIA_URL = f'https://{AWS_S3_CUSTOM_DOMAIN}/'

--- a/fitting/serializers.py
+++ b/fitting/serializers.py
@@ -17,3 +17,7 @@ class GenerateVTOProductRequestSerializer(serializers.Serializer):
     person_image_url  = serializers.URLField()
     outfit_image_url  = serializers.URLField()
     category = serializers.CharField()
+
+class VTOTestRequestSerializer(serializers.Serializer):
+    person_image = serializers.ImageField()
+    outfit_image = serializers.ImageField()

--- a/fitting/urls.py
+++ b/fitting/urls.py
@@ -4,4 +4,5 @@ from .views import *
 urlpatterns = [
     path('images',VTOOneShotView.as_view(),name='generate_vto'),
     path('images/products',VTOProductView.as_view(),name='generate_vto_product'),
+    path('images/test',VTOTestView.as_view(),name='vto_test'),
 ]

--- a/fitting/utils.py
+++ b/fitting/utils.py
@@ -1,0 +1,36 @@
+import os, io, uuid, boto3, requests
+
+s3 = boto3.client(
+    "s3",
+    aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+    aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+    region_name=os.getenv("AWS_S3_REGION_NAME"),
+)
+BUCKET = os.getenv("AWS_STORAGE_BUCKET_NAME")
+CLOUDFRONT_DOMAIN = os.getenv("AWS_S3_CUSTOM_DOMAIN")
+
+def upload_bytes(prefix: str, data: bytes, ext: str = "jpg") -> str:
+    key = f"{prefix}{uuid.uuid4()}.{ext}"
+    s3.upload_fileobj(
+        io.BytesIO(data),
+        BUCKET,
+        key,
+        ExtraArgs={
+            "ContentType": f"image/{ext}",
+            "ContentDisposition": "inline",
+        },
+    )
+    return f"{CLOUDFRONT_DOMAIN}/{key}"
+
+def upload_url(prefix: str, remote_url: str) -> str:
+    resp = requests.get(remote_url, timeout=30)
+    resp.raise_for_status()
+
+    # 확장자 안전 추출
+    filename = remote_url.split("/")[-1].split("?")[0]
+    if "." in filename:
+        ext = filename.split(".")[-1]
+    else:
+        ext = "jpg"
+
+    return upload_bytes(prefix, resp.content, ext)

--- a/fitting/views.py
+++ b/fitting/views.py
@@ -10,17 +10,19 @@ from django.conf import settings
 from openai import OpenAI
 from rest_framework.parsers import MultiPartParser, FormParser
 import base64
-from .serializers import GenerateVTORequestSerializer, VTORequestSerializer, GenerateVTOProductRequestSerializer
+from .serializers import GenerateVTORequestSerializer, VTORequestSerializer, GenerateVTOProductRequestSerializer, VTOTestRequestSerializer
 import requests
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from celery import chord
 from .tasks import run_vto_task, collect_paths, run_vto_url_task
+from .utils      import upload_bytes, upload_url
+from .models     import UserImage, FittingResult
 
-BITSTUDIO_API_KEY = os.getenv("BITSTUDIO_API_KEY")
 load_dotenv()
+BITSTUDIO_API_KEY = os.getenv("BITSTUDIO_API_KEY")
 
 class VTOOneShotView(GenericAPIView):
-    permission_classes = [AllowAny]
+    permission_classes = [IsAuthenticated]
     parser_classes = [parsers.MultiPartParser, parsers.FormParser]
     serializer_class = VTORequestSerializer
 
@@ -52,6 +54,15 @@ class VTOOneShotView(GenericAPIView):
         ser = self.get_serializer(data=request.data)
         ser.is_valid(raise_exception=True)
         data = ser.validated_data
+        
+        user_s3_url = upload_bytes("user/", data["person_image"].read())
+        
+        data["person_image"].seek(0)
+        
+        user_img_obj = UserImage.objects.create(
+            user_id=request.user if request.user.is_authenticated else None,
+            user_image_url=user_s3_url
+        )
 
         # 1) 이미지 업로드(두 장)
         person_id = self._upload_image(
@@ -115,7 +126,20 @@ class VTOOneShotView(GenericAPIView):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
-        return Response({"paths": paths})
+        vto_s3_url = upload_url("vto/", paths[0])
+
+        # 6-B) 피팅 결과 DB 저장
+        fit_obj = FittingResult.objects.create(
+            user_image=user_img_obj,
+            fitting_photo_url=vto_s3_url
+            )
+        
+        return Response({
+            "paths": paths,
+            "fitting_id": fit_obj.id,
+            "vto_image_s3": vto_s3_url,
+            "user_image_s3": user_s3_url,
+            })
 
     # ───────────────────────── helper methods ─────────────────────
     @staticmethod
@@ -131,7 +155,7 @@ class VTOOneShotView(GenericAPIView):
         return res.json()["id"]
     
 class VTOProductView(GenericAPIView):
-    permission_classes = [AllowAny]
+    permission_classes = [IsAuthenticated]
     serializer_class   = GenerateVTOProductRequestSerializer
 
     @swagger_auto_schema(
@@ -199,3 +223,127 @@ class VTOProductView(GenericAPIView):
             )
 
         return Response({"paths": paths}, status=200)
+    
+class VTOTestView(GenericAPIView):
+    """
+    로컬 사진 2장을 받아 Bitstudio VTO 1장을 동기식 생성 →  
+    ① 사용자 원본 사진 S3 업로드  
+    ② Bitstudio 결과 이미지를 S3 재업로드  
+    ③ 두 URL을 DB(UserImage, FittingResult)에 저장 후 반환
+    """
+    permission_classes = [IsAuthenticated]
+    parser_classes     = [parsers.MultiPartParser, parsers.FormParser]
+    serializer_class   = VTOTestRequestSerializer
+
+    # Swagger 수동 파라미터
+    file_param = lambda self, name, desc: openapi.Parameter(
+        name=name, in_=openapi.IN_FORM, description=desc,
+        type=openapi.TYPE_FILE, required=True
+    )
+
+    @swagger_auto_schema(
+        operation_summary="VTO 테스트 (파일 2장 → 결과 1장, S3 저장)",
+        consumes=["multipart/form-data"],
+        manual_parameters=[
+            file_param(None, "person_image",  "사람 전신 이미지"),
+            file_param(None, "outfit_image",  "의상(상품) 이미지"),
+        ],
+        responses={200: openapi.Response("OK")},
+    )
+    def post(self, request):
+        # 1) 입력 검증
+        ser = self.get_serializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        files = ser.validated_data
+
+        # 2) 사용자 원본 사진 S3 업로드 & DB 저장 --------------------------
+        user_s3_url = upload_bytes("user/", files["person_image"].read())
+        
+        files["person_image"].seek(0)
+        
+        user_img_obj = UserImage.objects.create(
+            user_id=request.user if request.user.is_authenticated else None,
+            user_image_url=user_s3_url
+        )
+
+        # 3) Bitstudio 업로드(파일) → image_id 확보 ------------------------
+        person_id = self._upload_image(files["person_image"], "virtual-try-on-person")
+        outfit_id = self._upload_image(files["outfit_image"], "virtual-try-on-outfit")
+
+        # 4) 단일 프롬프트
+        prompt = (
+            "Generate a realistic, high-quality full-body image of the input person "
+            "wearing the input clothing. Ensure natural fit and preserve facial features."
+        )
+
+        # 5) Bitstudio 동기 호출·폴링 ------------------------------
+        result_path = self._run_vto_inline(person_id, outfit_id, prompt)
+        if result_path is None:
+            return Response(
+                {"error": "VTO 생성 실패/타임아웃"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        # 6) Bitstudio 결과 S3 재업로드 & DB 저장 -------------------
+        vto_s3_url = upload_url("vto/", result_path)
+        fit_obj = FittingResult.objects.create(
+            user_image        = user_img_obj,
+            fitting_photo_url = vto_s3_url
+        )
+
+        return Response(
+            {
+                "user_image_s3": user_s3_url,
+                "vto_image_s3":  vto_s3_url,
+                "fitting_id":    fit_obj.id
+            },
+            status=200,
+        )
+
+    # ───────────────────────── helper methods ─────────────────────
+    @staticmethod
+    def _upload_image(file_obj, img_type):
+        r = requests.post(
+            "https://api.bitstudio.ai/images",
+            headers={"Authorization": f"Bearer {BITSTUDIO_API_KEY}"},
+            files={"file": file_obj, "type": (None, img_type)},
+            timeout=30,
+        )
+        r.raise_for_status()
+        return r.json()["id"]
+
+    @staticmethod
+    def _run_vto_inline(person_id, outfit_id, prompt) -> str | None:
+        try:
+            r = requests.post(
+                "https://api.bitstudio.ai/images/virtual-try-on",
+                headers={"Authorization": f"Bearer {BITSTUDIO_API_KEY}",
+                         "Content-Type":  "application/json"},
+                json={
+                    "person_image_id": person_id,
+                    "outfit_image_id": outfit_id,
+                    "prompt":         prompt,
+                    "resolution":     "standard",
+                    "num_images":     1,
+                    "style":          "studio",
+                },
+                timeout=30,
+            )
+            r.raise_for_status()
+            job_id = r.json()[0]["id"]
+
+            for _ in range(30):         # 2초 × 30 = 60초
+                info = requests.get(
+                    f"https://api.bitstudio.ai/images/{job_id}",
+                    headers={"Authorization": f"Bearer {BITSTUDIO_API_KEY}"},
+                    timeout=10,
+                ).json()
+
+                if info.get("status") == "completed":
+                    return info.get("path")
+                if info.get("status") == "failed":
+                    return None
+                time.sleep(2)
+            return None
+        except Exception:
+            return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ django-celery-beat==2.8.0
 django_celery_results==2.6.0
 kombu==5.5.3
 boto3==1.39.4
+django-storages==1.14.6


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

사용자 사진과 피팅 결과 s3에 저장 후 url을 db에 저장

### ✨ Description

<!-- write down the work details and show the execution results. -->
<img width="911" height="606" alt="image" src="https://github.com/user-attachments/assets/079df77d-63ef-4641-8055-5f1ff4a9465d" />
s3에 잘 저장되고
<img width="1514" height="436" alt="image" src="https://github.com/user-attachments/assets/87f141c0-a39f-4e94-84bc-4f1b67a0800c" />
url을 db에 저장 후 반환합니다.

erd 변경이 있을수도 있어서 확정은 아닙니다.

테스트뷰는 말그대로 테스트 코드입니다. 사진 4장을 테스트하기엔 비용이 들기 때문에 만들었습니다.



### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{24}
