### PR TITLE
[feat] 가상 피팅 사진 배경제거 기능구현

### DIFF
--- a/fitting/models.py
+++ b/fitting/models.py
@@ -27,10 +27,10 @@ class FittingResult(models.Model):
         related_name='fitting_results',
         verbose_name="사용자 아이디"
         )
-    product = models.OneToOneField(
+    product = models.ForeignKey(
         'product.Product',
         on_delete=models.CASCADE,
-        related_name='fitting_result',
+        related_name='fitting_results',
         verbose_name="상품 아이디"
         )
     image = models.CharField(max_length=255, null=True, blank=True, verbose_name="피팅사진 주소")
@@ -41,6 +41,9 @@ class FittingResult(models.Model):
 
     class Meta:
         db_table = 'fitting_result'
+        unique_together = [
+            ('user', 'product'),
+            ]
 
     def __str__(self):
         return f"FittingResult {self.id} - User {self.user_id} - Product {self.product_id}"

--- a/fitting/serializers.py
+++ b/fitting/serializers.py
@@ -21,3 +21,16 @@ class GenerateVTOProductRequestSerializer(serializers.Serializer):
 class VTOTestRequestSerializer(serializers.Serializer):
     person_image = serializers.ImageField()
     outfit_image = serializers.ImageField()
+
+class ChangeBgSerializer(serializers.Serializer):
+    image     = serializers.CharField(required=False)     # URL
+    image_file = serializers.ImageField(required=False)   # 업로드 파일
+    replace   = serializers.CharField(default="white studio")
+    negative  = serializers.CharField(required=False, allow_blank=True)
+
+    def validate(self, data):
+        if not (data.get("image") or data.get("image_file")):
+            raise serializers.ValidationError("image 또는 image_file 중 하나는 필수입니다.")
+        # 하나만 남기도록 정리
+        data["image"] = data.pop("image_file", data.get("image"))
+        return data

--- a/fitting/urls.py
+++ b/fitting/urls.py
@@ -5,5 +5,8 @@ urlpatterns = [
     path('images_test',VTOOneShotView.as_view(),name='generate_vto'),
     path('images/products',VTOProductView.as_view(),name='generate_vto_product'),
     path('images/test',VTOTestView.as_view(),name='vto_test'),
-    path('images', ProductFittingGenerateView.as_view(), name='generate_product_fitting'),
+    path('images', ProductFittingGenerateView.as_view(),name='generate_product_fitting'),
+    path('images/remove-bg', RemoveBgView.as_view(),name='remove_bg_test'),
+    path('images/edit-bg-white', EditBgWhiteView.as_view(),name='edit_bg_white'),
+    path('images/detail',ProductFittingGenerateDetailView.as_view(),name='generate_product_detail_fitting'),
 ]


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

### 가상 피팅 사진 배경 제거 기능구현

### ✨ Description

<!-- write down the work details and show the execution results. -->

기존의 가상 피팅 사진만 저장하는 기능에서 배경을 스튜디오 느낌으로 만들고 저장하도록 구현했습니다.
<img width="3422" height="604" alt="image" src="https://github.com/user-attachments/assets/e4b78fb4-dd6a-4fd5-a3dd-4af03a944f8b" />
상품은 2개로 테스트 해보았습니다.
셀러리 태스크에는 각 상품마다 다음과 같은 작업이 실행됩니다.
1. 가상 피팅
2. 배경 제거
3. s3업로드 후 db에 저장

총 셀러리 태스크는 6개이겠죠

시간은 약 50초 소요입니다.

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{59}
