### PR TITLE
[feat] 사용자 전신사진 바꾸기 구현

### DIFF
--- a/user/models.py
+++ b/user/models.py
@@ -27,6 +27,7 @@ class CartItem(models.Model):
     product = models.ForeignKey(Product, on_delete=models.CASCADE)
     quantity = models.PositiveIntegerField(default=1)
     created_at = models.DateTimeField(auto_now_add=True)
+    is_fitting = models.BooleanField(default=False, verbose_name="합성 여부")
 
     class Meta:
         unique_together = ('user', 'product')

--- a/user/urls.py
+++ b/user/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import SignUpAPI, LoginView, LogoutView, CookieTokenRefreshView, CartItemCreateAPIView, CartItemListAPIView, CartItemUpdateAPIView
+from .views import SignUpAPI, LoginView, LogoutView, CookieTokenRefreshView, CartItemCreateAPIView, CartItemListAPIView, CartItemUpdateAPIView, UpdateProfileImageAPI
 
 urlpatterns = [
     path("signup", SignUpAPI.as_view(), name="api-signup"),
@@ -9,4 +9,5 @@ urlpatterns = [
     path('cart', CartItemCreateAPIView.as_view(), name='cart-add'),
     path('cart/list', CartItemListAPIView.as_view(), name='cart-list'),
     path('cart/<int:cart_product_id>', CartItemUpdateAPIView.as_view(), name='cart-update'),
+    path("profile-image", UpdateProfileImageAPI.as_view(), name="update_profile_image"),
 ]


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

사용자 전신사진 바꾸기 구현

### ✨ Description

<!-- write down the work details and show the execution results. -->

사용자가 회원가입 할 때 등록한 전신사진(profile_image)을 수정할 수 있도록 구현했다.

우선, user/views.py에 'UpdateProfileImageAPI'라는 클래스를 새로 지정하여 사용자 등록 사진을 변경할 수 있도록 코드를 작성하였다.

후에, 스위치에 따라 변경되는 플래그에 기능을 추가하였다.  사용자가 등록 사진을 변경하면 'is_fitting = False'로 리셋 되도록 구현하였다.
User 클래스에 
is_fitting = models.BooleanField(default=False, verbose_name="합성 여부")
필드를 추가하였고,
UpdateProfileImageAPI 클래스에
CartItem.objects.filter(user=user).update(is_fitting=False)
를 추가하여 구현하였다.

중간에 is_fitting 필드 추가 후 마이그레이션이 누락되어 트래킹 오류가 발생했다. 이를 해결하기 위해 기존 도커 볼륨을 삭제하고 초기 상태부터 다시 마이그레이션을 적용하였다.

<img width="958" height="271" alt="image" src="https://github.com/user-attachments/assets/8090e986-4057-4523-8655-a319e34686d4" />
결과적으로 데이터베이스에서 is_fitting 값이 0으로 올바르게 나타나는 것을 확인할 수 있다.

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #72 
