### PR TITLE
[feat] access 토큰 유효 시간 늘리기

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -3,6 +3,7 @@ import pymysql
 from datetime import timedelta
 from dotenv import load_dotenv
 from kombu import Queue
+from datetime import timedelta
 
 pymysql.install_as_MySQLdb()
 load_dotenv()
@@ -101,9 +102,24 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 SIMPLE_JWT = {
-    "AUTH_COOKIE_ACCESS": "access",     
-    "AUTH_COOKIE_REFRESH": "refresh",
-    "AUTH_COOKIE_SAMESITE": "Lax",
+    # 🔑 JWT 설정
+    "ACCESS_TOKEN_LIFETIME": timedelta(days=1),   # ✅ access 토큰 1일
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=7),  # 보통 7일~14일 정도
+
+    "ROTATE_REFRESH_TOKENS": False,
+    "BLACKLIST_AFTER_ROTATION": True,
+    "AUTH_HEADER_TYPES": ("Bearer",),
+
+    # 🍪 쿠키 관련 커스텀 설정 (이미 있는 값 유지 + 필요시 추가)
+    "AUTH_COOKIE_ACCESS": "access",      # access 토큰을 담는 쿠키 이름
+    "AUTH_COOKIE_REFRESH": "refresh",    # refresh 토큰을 담는 쿠키 이름
+    "AUTH_COOKIE_SAMESITE": "Lax",       
+    "AUTH_COOKIE_SECURE": False,         # 운영에서는 True 권장 (HTTPS일 때)
+    "AUTH_COOKIE_HTTP_ONLY": True,       # JS 접근 방지용
+    "AUTH_COOKIE_PATH": "/",
+    "AUTH_COOKIE_DOMAIN": None,          # 필요하면 도메인 명시
+    "AUTH_COOKIE_ACCESS_MAX_AGE": 60 * 60 * 24,  # ✅ access 쿠키 유지 1일
+    "AUTH_COOKIE_REFRESH_MAX_AGE": 60 * 60 * 24 * 7,  # refresh 쿠키 유지 7일
 }
 
 REST_FRAMEWORK = {

--- a/user/views.py
+++ b/user/views.py
@@ -77,12 +77,25 @@ class LoginView(APIView):
         }
 
         resp = Response(data, status=status.HTTP_200_OK)
-        resp.set_cookie("access",  data["access_token"],
-                        httponly=True, samesite="Lax",
-                        secure=not settings.DEBUG, path="/", max_age=60*60)
-        resp.set_cookie("refresh", data["refresh_token"],
-                        httponly=True, samesite="Lax",
-                        secure=not settings.DEBUG, path="/", max_age=60*60*24*7)
+        resp.set_cookie(
+            key=settings.SIMPLE_JWT.get("AUTH_COOKIE_ACCESS", "access"),
+            value=data["access_token"],
+            httponly=settings.SIMPLE_JWT.get("AUTH_COOKIE_HTTP_ONLY", True),
+            samesite=settings.SIMPLE_JWT.get("AUTH_COOKIE_SAMESITE", "Lax"),
+            secure=settings.SIMPLE_JWT.get("AUTH_COOKIE_SECURE", not settings.DEBUG),
+            path=settings.SIMPLE_JWT.get("AUTH_COOKIE_PATH", "/"),
+            max_age=settings.SIMPLE_JWT.get("AUTH_COOKIE_ACCESS_MAX_AGE", 60 * 60 * 24),
+        )
+
+        resp.set_cookie(
+            key=settings.SIMPLE_JWT.get("AUTH_COOKIE_REFRESH", "refresh"),
+            value=data["refresh_token"],
+            httponly=settings.SIMPLE_JWT.get("AUTH_COOKIE_HTTP_ONLY", True),
+            samesite=settings.SIMPLE_JWT.get("AUTH_COOKIE_SAMESITE", "Lax"),
+            secure=settings.SIMPLE_JWT.get("AUTH_COOKIE_SECURE", not settings.DEBUG),
+            path=settings.SIMPLE_JWT.get("AUTH_COOKIE_PATH", "/"),
+            max_age=settings.SIMPLE_JWT.get("AUTH_COOKIE_REFRESH_MAX_AGE", 60 * 60 * 24 * 7),
+        )
         return resp
     
 class LogoutView(APIView):
@@ -146,14 +159,15 @@ class CookieTokenRefreshView(TokenRefreshView):
             status=status.HTTP_200_OK
         )
         resp.set_cookie(
-            key="access",
-            value=access_token,
-            httponly=True,
-            samesite="Lax",
-            secure=not settings.DEBUG,
-            path="/",
-            max_age=60 * 15,    
+        key=settings.SIMPLE_JWT.get("AUTH_COOKIE_ACCESS", "access"),
+        value=access_token,
+        httponly=settings.SIMPLE_JWT.get("AUTH_COOKIE_HTTP_ONLY", True),
+        samesite=settings.SIMPLE_JWT.get("AUTH_COOKIE_SAMESITE", "Lax"),
+        secure=settings.SIMPLE_JWT.get("AUTH_COOKIE_SECURE", not settings.DEBUG),
+        path=settings.SIMPLE_JWT.get("AUTH_COOKIE_PATH", "/"),
+        max_age=settings.SIMPLE_JWT.get("AUTH_COOKIE_ACCESS_MAX_AGE", 60 * 60 * 24), 
         )
+
         return resp
     
 class CartItemCreateAPIView(APIView):


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

access 토큰 유효 시간 늘리기

### ✨ Description

<!-- write down the work details and show the execution results. -->

지금까지 시도한 set_cookie를 수정한 방식은 JWT의 만료량과는 별개로, 쿠키가 브라우저에서 언제 만료되는지 제어하는 방법이다. JWT 내부의 만료시간을 조정하기 위해 settings에 base.py에서 SIMPLE_JWT 설정을 추가하여 access 토큰 만료 시간을 하루(60*60*24)로 조정하였다. set_cookie 에서도 시간을 함께 수정하였다.

<img width="2032" height="142" alt="image" src="https://github.com/user-attachments/assets/275b0258-d7c7-4c07-9978-9e5f2b0bb825" />
개발자 도구에서 access 토큰 값은 24시간, refresh 토큰 값은 7일로 조정된 것을 확인할 수 있다.

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #79 
