### PR TITLE
feat : 이미지 리사이징을 통한 이미지 용량 줄이기 구현

### DIFF
--- a/fitting/utils.py
+++ b/fitting/utils.py
@@ -1,4 +1,5 @@
-import os, io, uuid, boto3, requests
+from PIL import Image
+import io, os, uuid, boto3
 
 s3 = boto3.client(
     "s3",
@@ -8,6 +9,28 @@ s3 = boto3.client(
 )
 BUCKET = os.getenv("AWS_STORAGE_BUCKET_NAME")
 CLOUDFRONT_DOMAIN = os.getenv("AWS_S3_CUSTOM_DOMAIN")
+
+def resize_image_keep_ratio(image_bytes, max_size=(800, 800), quality=90):
+    """
+    원본 비율 유지, 긴 변이 max_size 미만이 되도록 리사이즈 후 JPEG 저장 (용량 ↓)
+    """
+    with Image.open(io.BytesIO(image_bytes)) as img:
+        img = img.convert("RGB")
+        img.thumbnail(max_size, Image.LANCZOS)   # 비율 유지
+        buffer = io.BytesIO()
+        img.save(buffer, format="JPEG", quality=quality, optimize=True)
+        return buffer.getvalue()
+
+def compress_image_bytes(image_bytes, quality=90):
+    """
+    해상도 그대로, JPEG 재압축만 수행 (원본 크기 유지, 용량만 ↓)
+    """
+    with Image.open(io.BytesIO(image_bytes)) as img:
+        img = img.convert("RGB")
+        buffer = io.BytesIO()
+        img.save(buffer, format="JPEG", quality=quality, optimize=True)
+        return buffer.getvalue()
+    
 
 def upload_bytes(prefix: str, data: bytes, ext: str = "jpg") -> str:
     key = f"{prefix}{uuid.uuid4()}.{ext}"
@@ -55,15 +78,21 @@ def upload_fitting_image_to_s3(
     )
     return f"{CLOUDFRONT_DOMAIN}/{key}"
 
-def upload_bytes(prefix: str, data: bytes, ext: str = "jpg") -> str:
-    key = f"{prefix}{uuid.uuid4()}.{ext}"
+def upload_fitting_image_to_s3(user_id, product_id, image_data, ext="jpg", resize=True):
+    """
+    리사이즈/재압축 후 S3 저장. resize=False면 해상도 그대로, True면 800x800 이하 비율 유
+    """
+    if resize:
+        # 원본 비율 유지, 800px 이하로 리사이즈
+        image_bytes = resize_image_keep_ratio(image_data, max_size=(800, 800))
+    else:
+        # 해상도 그대로, 재압축만
+        image_bytes = compress_image_bytes(image_data)
+    key = f"fitting_images/{user_id}/{product_id}/{uuid.uuid4()}.{ext}"
     s3.upload_fileobj(
-        io.BytesIO(data),
+        io.BytesIO(image_bytes),
         BUCKET,
         key,
-        ExtraArgs={
-            "ContentType": f"{'video' if ext=='mp4' else 'image'}/{ext}",
-            "ContentDisposition": "inline",
-        },
+        ExtraArgs={"ContentType": f"image/{ext}", "ContentDisposition": "inline"},
     )
     return f"{CLOUDFRONT_DOMAIN}/{key}"

--- a/product/serializers.py
+++ b/product/serializers.py
@@ -10,11 +10,13 @@ class ProductCreateSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         image_file = validated_data.pop('image_file')
-        from .utils import upload_image_to_s3  # S3 업로드 함수
+        image_bytes = image_file.read()
 
-        # S3 업로드 후 URL 획득
-        s3_url = upload_image_to_s3(image_file, folder='model_images/')
+        from .utils import upload_product_image
+        # product 생성 전 임시 product_id 할당: 새 product의 PK가 실제로 필요한 경우엔 저장 후 처리
+        product = Product.objects.create(**validated_data, image='')  # 먼저 인스턴스 생성
+        s3_url = upload_product_image(product.id, image_bytes)
 
-        # 상품 등록
-        product = Product.objects.create(image=s3_url, **validated_data)
+        product.image = s3_url
+        product.save(update_fields=["image"])
         return product

--- a/product/utils.py
+++ b/product/utils.py
@@ -1,4 +1,5 @@
 import os, io, uuid, boto3
+from PIL import Image
 
 s3 = boto3.client(
     "s3",
@@ -10,32 +11,25 @@ s3 = boto3.client(
 BUCKET = os.getenv("AWS_STORAGE_BUCKET_NAME")
 CLOUDFRONT_DOMAIN = os.getenv("AWS_S3_CUSTOM_DOMAIN")
 
+def resize_image_keep_ratio(image_bytes, max_size=(800, 800), quality=90):
+    """
+    긴 변이 max_size(예: 800px)를 넘지 않도록 원본 비율을 유지해서 리사이즈
+    """
+    with Image.open(io.BytesIO(image_bytes)) as img:
+        img = img.convert("RGB")
+        img.thumbnail(max_size, Image.LANCZOS)  # 비율 유지 & 축소
+        buffer = io.BytesIO()
+        img.save(buffer, format="JPEG", quality=quality, optimize=True)
+        return buffer.getvalue()
 
 def upload_product_image(product_id: int, image_bytes: bytes, ext: str = "jpg") -> str:
     """
-    상품 ID 기반으로 S3에 이미지 저장 후 CloudFront URL 반환
-    model_images/{product_id}/{uuid}.jpg 형식
+    비율유지 리사이즈 → S3에 업로드
     """
-    key = f"model_images/{product_id}/{uuid.uuid4()}.{ext}"
-    s3.upload_fileobj(
-        io.BytesIO(image_bytes),
-        BUCKET,
-        key,
-        ExtraArgs={
-            "ContentType": f"image/{ext}",
-            "ContentDisposition": "inline",
-        },
-    )
-    return f"{CLOUDFRONT_DOMAIN}/{key}"
-
-def upload_product_image(product_id: int, image_bytes: bytes, ext: str = "jpg") -> str:
-    """
-    상품 ID 하위로 이미지를 저장하고 CloudFront URL 반환
-    product_images/{product_id}/{uuid}.jpg
-    """
+    resized_bytes = resize_image_keep_ratio(image_bytes, max_size=(800, 800))
     key = f"product_images/{product_id}/{uuid.uuid4()}.{ext}"
     s3.upload_fileobj(
-        io.BytesIO(image_bytes),
+        io.BytesIO(resized_bytes),
         BUCKET,
         key,
         ExtraArgs={

--- a/user/utils.py
+++ b/user/utils.py
@@ -1,4 +1,5 @@
 import os, io, uuid, boto3
+from PIL import Image
 
 s3 = boto3.client(
     "s3",
@@ -10,10 +11,23 @@ s3 = boto3.client(
 BUCKET = os.getenv("AWS_STORAGE_BUCKET_NAME")
 CLOUDFRONT_DOMAIN = os.getenv("AWS_S3_CUSTOM_DOMAIN")
 
-def upload_profile_image_to_s3(user_id: str, data: bytes, ext: str = "jpg") -> str:
+def resize_image_keep_ratio(image_bytes, max_size=(800, 800), quality=90):
+    """
+    원본 비율을 유지하여 긴 변이 max_size 이하가 되도록 리사이즈
+    """
+    with Image.open(io.BytesIO(image_bytes)) as img:
+        img = img.convert("RGB")
+        img.thumbnail(max_size, Image.LANCZOS)  # 비율 유지 자동
+        buffer = io.BytesIO()
+        img.save(buffer, format="JPEG", quality=quality, optimize=True)
+        return buffer.getvalue()
+
+def upload_profile_image_to_s3(user_id: str, image_bytes: bytes, ext: str = "jpg") -> str:
+    # 리사이즈 적용
+    resized_bytes = resize_image_keep_ratio(image_bytes, max_size=(800, 800))
     key = f"profiles/{user_id}/{uuid.uuid4()}.{ext}"
     s3.upload_fileobj(
-        io.BytesIO(data),
+        io.BytesIO(resized_bytes),
         BUCKET,
         key,
         ExtraArgs={

--- a/user/views.py
+++ b/user/views.py
@@ -36,17 +36,18 @@ class SignUpAPI(generics.CreateAPIView):
 
         if image_file:
             image_bytes = image_file.read()
-            profile_image_url = upload_profile_image_to_s3(str(user.id), image_bytes)
-
+            ext = image_file.name.split('.')[-1].lower()
+            profile_image_url = upload_profile_image_to_s3(str(user.id), image_bytes, ext)
             user.profile_image = profile_image_url
-            user.save() 
-
+            user.is_fitting = False
+            user.save()
+            
         return Response({
             "message": "회원가입이 완료되었습니다.",
             "user_id": user.id,
             "profile_image_url": user.profile_image
         }, status=201)
-
+                
 class LoginView(APIView):
     serializer_class = LoginSerializer
     permission_classes = [AllowAny]


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

--- feat : 이미지 리사이징을 통한 이미지 용량 줄이기 구현

### ✨ Description

<!-- write down the work details and show the execution results. -->

---
<img width="610" height="915" alt="image" src="https://github.com/user-attachments/assets/7d857ee7-e1d2-44d2-b138-fbceeeb30f2a" />
<img width="1640" height="2034" alt="image" src="https://github.com/user-attachments/assets/49d91d53-df54-43fd-bee3-e6251e1251da" />

두 개의 이미지를 통해 사용자에게 옷을 피팅 해준 결과

<img width="1278" height="1716" alt="image" src="https://github.com/user-attachments/assets/2498f13c-fdd8-467a-ac60-7a1d15294145" />

피팅을 마치고 나온 사진의 용량이 기존에는 130-150KB 였다면, 이미지 리사이징을 통해 30-40KB로 줄였다.
