### PR TITLE
feat : 유저 사진과 그에 관련된 피팅 사진까지 지워주는 기능 구현

### DIFF
--- a/product/urls.py
+++ b/product/urls.py
@@ -4,5 +4,5 @@ from .views import ProductCreateListView, ProductDetailImageView, ProductFitting
 urlpatterns = [
     path('', ProductCreateListView.as_view(), name='product-create'),                         # POST /products/
     path('<int:product_id>', ProductDetailImageView.as_view(), name='product-detail'),        # GET  /products/{product_id}    path('<int:product_id>/images', ProductDetailImageView.as_view(), name='product-images'), # POST /products/{product_id}/images
-    path('<int:product_id>/images/<user_image>', ProductFittingImageView.as_view(), name='product-fitting-image'),
+    path('<int:product_id>/images/<int:user_image>', ProductFittingImageView.as_view(), name='product-fitting-image'),
 ]

--- a/user/urls.py
+++ b/user/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
     path('cart/<int:cart_product_id>', CartItemUpdateAPIView.as_view(), name='cart-update'),
     path("profile-image", UpdateProfileImageAPI.as_view(), name="update_profile_image"),
     path("images", UserImageListAPI.as_view(), name="user_image_list"),
+    path('images/<int:user_image_id>', UserImageDeleteAPI.as_view(), name='users_image_delete'),
 ]

--- a/user/views.py
+++ b/user/views.py
@@ -17,6 +17,9 @@ from django.conf import settings
 from .utils import upload_profile_image_to_s3
 from .models import CartItem, UserImage
 from product.models import Product
+from django.shortcuts import get_object_or_404
+from django.db import transaction
+from fitting.models import FittingResult
 
 class SignUpAPI(generics.CreateAPIView):
     serializer_class = SignUpSerializer
@@ -30,7 +33,7 @@ class SignUpAPI(generics.CreateAPIView):
 
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        user = serializer.save() 
+        user = serializer.save()
             
         return Response({
             "message": "회원가입이 완료되었습니다.",
@@ -309,3 +312,24 @@ class UserImageListAPI(APIView):
         user_images = UserImage.objects.filter(user=request.user)
         serializer = UserImageSerializer(user_images, many=True)
         return Response(serializer.data)
+
+class UserImageDeleteAPI(APIView):
+    permission_classes = [IsAuthenticated]
+
+    @swagger_auto_schema(
+        operation_summary="사용자 이미지 및 피팅 결과 삭제",
+        operation_description="user_image_id로 사용자 이미지를 삭제하며, 연결된 모든 fitting_result(가상 피팅 결과)도 함께 삭제합니다.",
+        responses={
+            204: "삭제 성공",
+            403: "권한 없음",
+            404: "존재하지 않음",
+        }
+    )
+    def delete(self, request, user_image_id):
+        user_image = get_object_or_404(UserImage, pk=user_image_id, user=request.user)
+        with transaction.atomic():
+            # 연결된 fitting_result 모두 삭제
+            FittingResult.objects.filter(user_image=user_image).delete()
+            # user_image 자체도 삭제
+            user_image.delete()
+        return Response(status=204)


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

---feat : 유저 사진과 그에 관련된 피팅 사진까지 지워주는 기능 구현



### ✨ Description

<!-- write down the work details and show the execution results. -->

---
<img width="1436" height="606" alt="image" src="https://github.com/user-attachments/assets/81ee0e7e-7369-4cd7-af62-5959357e6793" />

사용자가 등록한 이미지를 지워주는 기능 구현
이미지를 지워주며 그 이미로 인해 생성된 가상피팅 사진까지 지워주는 기능 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint allowing users to delete their uploaded images along with any related fitting results.

* **Bug Fixes**
  * Updated URL patterns to ensure only integer values are accepted for certain image-related routes, improving input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->