### PR TITLE
[feat] cpu 바운드, i/o 바운드 작업 큐와 워커 나눠서 설정

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -2,12 +2,27 @@ from __future__ import absolute_import, unicode_literals
 import os
 from celery import Celery
 import logging
+from kombu import Queue
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.prod')
 
 app = Celery('backend', broker='amqp://guest:guest@rabbitmq:5672/')
 
 app.config_from_object('django.conf:settings', namespace='CELERY')
+
+app.conf.task_routes = {
+    # I/O 작업
+    "fitting.tasks.run_vto_edit_url_task": {"queue": "io"},
+    "fitting.tasks.edit_bg_task":          {"queue": "io"},
+    "fitting.tasks.save_to_s3_and_db":     {"queue": "io"},
+    # CPU 작업
+    "fitting.tasks.resize":                {"queue": "cpu"},
+}
+
+app.conf.task_queues = (
+    Queue("io"),   # I/O 전용
+    Queue("cpu"),  # CPU 전용
+)
 
 app.autodiscover_tasks()
 

--- a/config/celery.py
+++ b/config/celery.py
@@ -16,7 +16,7 @@ app.conf.task_routes = {
     "fitting.tasks.edit_bg_task":          {"queue": "io"},
     "fitting.tasks.save_to_s3_and_db":     {"queue": "io"},
     # CPU 작업
-    "fitting.tasks.resize":                {"queue": "cpu"},
+    "fitting.tasks.resize_image_task":     {"queue": "cpu"},
 }
 
 app.conf.task_queues = (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
     networks:
       - Backend-Net
 
-  celery_worker:
+  celery_io:
     build:
       context: .
     volumes:
@@ -109,6 +109,7 @@ services:
       celery -A config worker
       --pool=eventlet
       --concurrency=250
+      --queues=io
       --loglevel=info
     environment:
       - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672//
@@ -118,6 +119,29 @@ services:
       - backend
     restart: always
     tty: true
+    networks:
+      - Backend-Net
+    labels:
+      - "traefik.enable=false"
+
+  celery_cpu:
+    build:
+      context: .
+    volumes:
+      - ./:/app
+    command: >
+      celery -A config worker
+      --pool=prefork
+      --concurrency=4
+      --queues=cpu
+      -E --loglevel=info
+    environment:
+      - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672//
+      - DJANGO_SETTINGS_MODULE=config.settings.dev
+    depends_on:
+      - rabbitmq
+      - backend
+    restart: always
     networks:
       - Backend-Net
     labels:
@@ -153,7 +177,8 @@ services:
       - '5555:5555'
     depends_on:
       - rabbitmq
-      - celery_worker
+      - celery_io
+      - celery_cpu
       - celery_beat
     networks:
       - Backend-Net

--- a/fitting/tasks.py
+++ b/fitting/tasks.py
@@ -10,6 +10,7 @@ from fitting.models import FittingResult
 from fitting.utils import upload_fitting_image_to_s3, upload_video_to_s3
 from celery import group, chain
 from celery.exceptions import Ignore
+from PIL import Image
 
 
 BITSTUDIO_API_KEY = os.environ["BITSTUDIO_API_KEY"]
@@ -58,21 +59,13 @@ def run_vto_url_task(self, person_url, outfit_url, prompt):
         raise self.retry(exc=exc)
     
 @shared_task(bind=True, max_retries=2, default_retry_delay=10)
-def save_to_s3_and_db(self, vto_url: str, user_image_id: int, product_id: int):
-    if not vto_url:
-        return None   # 이전 태스크 실패한 경우
+def save_to_s3_and_db(self, resized_bytes: bytes, user_image_id: int, product_id: int):
 
     try:
-        # 1) 이미지 다운로드
-        resp = requests.get(vto_url, timeout=30)
-        resp.raise_for_status()
-        img_bytes = resp.content
-
-        # 2) S3 업로드
         s3_url = upload_fitting_image_to_s3(
             user_image_id=user_image_id,
             product_id=product_id,
-            image_data=img_bytes
+            image_data=resized_bytes
         )
 
         # 3) DB 저장
@@ -177,6 +170,25 @@ def edit_bg_task(self, vto_image_id):
             return None
         time.sleep(5)
     return None
+
+@shared_task(bind=True, autoretry_for=(requests.RequestException,),retry_backoff=5, retry_kwargs={'max_retries': 3}, queue="io")
+def download_image_task(self, vto_url: str):
+    resp = requests.get(vto_url, timeout=30)
+    resp.raise_for_status()
+    return resp.content
+
+
+def resize_image_keep_ratio(b: bytes, max_size=(800, 800), quality=90):
+    with Image.open(io.BytesIO(b)) as img:
+        img = img.convert("RGB")
+        img.thumbnail(max_size, Image.LANCZOS)
+        buf = io.BytesIO()
+        img.save(buf, "JPEG", quality=quality, optimize=True)
+        return buf.getvalue()
+
+@shared_task(bind=True, queue="cpu")
+def resize_image_task(self, img_bytes: bytes):
+    return resize_image_keep_ratio(img_bytes)
 
 @shared_task
 def generate_fitting_video_task(fitting_id, task_id):

--- a/fitting/views.py
+++ b/fitting/views.py
@@ -14,7 +14,7 @@ from .serializers import GenerateVTORequestSerializer, VTORequestSerializer, Gen
 import requests
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from celery import chord
-from .tasks import run_vto_url_task, save_to_s3_and_db, run_vto_edit_url_task, edit_bg_task, generate_fitting_video_task, fake_run_vto, fake_edit_bg, fake_save_to_s3_and_db
+from .tasks import run_vto_url_task, save_to_s3_and_db, run_vto_edit_url_task, edit_bg_task, generate_fitting_video_task, fake_run_vto, fake_edit_bg, fake_save_to_s3_and_db, download_image_task, resize_image_task
 from .utils      import upload_profile_image_to_s3
 from .models     import UserImage
 from celery import group, chain
@@ -311,6 +311,8 @@ class ProductFittingGenerateDetailView(APIView):
             task_chain = chain(
                 run_vto_edit_url_task.s(person_url, product.image, prompt),
                 edit_bg_task.s(),
+                download_image_task.s(),
+                resize_image_task.s(),
                 save_to_s3_and_db.s(user_image.id, product.id),
             )
             # 3개마다 1초씩 지연: idx 0,1,2 -> 0s, 3,4,5 -> 1s, …

--- a/fitting/views.py
+++ b/fitting/views.py
@@ -479,7 +479,7 @@ class ProductFittingGenerateMockDetailView(APIView):
         if user.is_fitting:
             return Response({"error": "이미 가상 피팅을 완료했거나 피팅 중입니다."}, status=400)
 
-        person_url = user.profile_image
+        person_url = UserImage.objects.get(pk=1).image
         if not person_url:
             return Response({"error": "사용자 사진이 없습니다."}, status=400)
 

--- a/product/tasks.py
+++ b/product/tasks.py
@@ -1,0 +1,17 @@
+import io
+from PIL import Image
+from celery import shared_task
+
+def resize_image_keep_ratio(image_bytes, max_size=(800, 800), quality=90):
+    """(이미 있던 헬퍼 그대로 복사)"""
+    with Image.open(io.BytesIO(image_bytes)) as img:
+        img = img.convert("RGB")
+        img.thumbnail(max_size, Image.LANCZOS)
+        buf = io.BytesIO()
+        img.save(buf, "JPEG", quality=quality, optimize=True)
+        return buf.getvalue()
+
+@shared_task
+def resize_one(image_bytes: bytes) -> int:
+    """리사이즈 후 바이트 크기를 반환(테스트 용도)"""
+    return len(resize_image_keep_ratio(image_bytes))

--- a/product/urls.py
+++ b/product/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import ProductCreateListView, ProductDetailImageView, ProductFittingImageView
+from .views import ProductCreateListView, ProductDetailImageView, ProductFittingImageView, ResizeBenchView
 
 urlpatterns = [
     path('', ProductCreateListView.as_view(), name='product-create'),                         # POST /products/
     path('<int:product_id>', ProductDetailImageView.as_view(), name='product-detail'),        # GET  /products/{product_id}    path('<int:product_id>/images', ProductDetailImageView.as_view(), name='product-images'), # POST /products/{product_id}/images
     path('<int:product_id>/images/<user_image>', ProductFittingImageView.as_view(), name='product-fitting-image'),
+    path('resize', ResizeBenchView.as_view(), name='resize_image'),      
 ]

--- a/product/views.py
+++ b/product/views.py
@@ -13,6 +13,11 @@ from .models import Product, ProductImage
 from .utils import upload_product_image
 from fitting.models import FittingResult
 
+from typing import Dict, List
+from celery import group
+import time
+from .tasks import resize_one
+
 class ProductCreateListView(APIView):
     permission_classes = [AllowAny]
     parser_classes = (MultiPartParser, FormParser)
@@ -182,3 +187,42 @@ class ProductFittingImageView(APIView):
             "user_image_id": user_image_obj.id,
             "fitting_image": fitting_result.image
         }, status=200)
+        
+class ResizeBenchView(APIView):
+    """
+    POST /api/bench/resize
+      - form‑data: image_file (필수)
+    Celery 워커가 리사이즈 100장을 처리하는 데 걸린 총 시간을 반환
+    """
+    permission_classes = [AllowAny]
+    parser_classes = (MultiPartParser, FormParser)
+
+    @swagger_auto_schema(
+        operation_id="benchmarkResize",
+        operation_summary="Celery 워커 벤치마크 (스레드·프로세스 풀 X)",
+        manual_parameters=[
+            openapi.Parameter(
+                "image_file",
+                openapi.IN_FORM,
+                description="테스트용 이미지(JPEG/PNG) 1장",
+                type=openapi.TYPE_FILE, required=True
+            )
+        ],
+        responses={200: "OK", 400: "Bad Request"},
+    )
+    def post(self, request):
+        time.sleep(5)
+        image_file = request.FILES.get("image_file")
+        if not image_file:
+            return Response({"error": "image_file 필드가 필요합니다."}, status=400)
+
+        original = image_file.read()
+        COPIES = 200
+        images: List[bytes] = [original] * COPIES
+
+        # Celery 그룹 태스크 발행
+        g = group(resize_one.s(b) for b in images)
+
+        start = time.perf_counter()
+        g.apply_async(ignore_result=True)
+        return Response({"msg": "queued"}, status=202)


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

cpu 바운드, i/o 바운드 작업 큐와 워커 나눠서 설정

### ✨ Description

<!-- write down the work details and show the execution results. -->

이미지 리사이징 같은 경우 cpu바운드 작업이라 스레드 풀 기반으로 했을 경우 스레드 1개나 200개나 차이가 없는 것을 확인하였습니다.
해당 작업은 프로세스를 여러개 둘 때 병렬 처리된다는 것을 확인하였습니다.

cpu 바운드 큐와 i/o 바운드 큐를 나누고 워커 또한 prefork 기반 워커, 스레드 풀 기반 워커로 나누었습니다.

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{141}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new API endpoint for benchmarking image resizing, allowing bulk asynchronous processing of images.
  * Added new endpoints to support image resizing and expanded image retrieval options.
  * Implemented separate Celery tasks for downloading, resizing, and saving images, enhancing modularity and performance.
  * Added a dedicated Celery worker for CPU-bound and I/O-bound tasks with explicit queue routing.

* **Improvements**
  * Refined the asynchronous processing pipeline for product fitting, adding distinct steps for downloading and resizing images.
  * Updated service definitions to split Celery workers by workload type for better resource utilization.

* **Bug Fixes**
  * Adjusted the mock product fitting process to use a consistent image source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->